### PR TITLE
Make consts public

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -13,12 +13,12 @@ class Agent extends MobileDetect
     /**
      * A type for the version() method indicating a string return value.
      */
-    protected const VERSION_TYPE_STRING = 'text';
+    public const VERSION_TYPE_STRING = 'text';
 
     /**
      * A type for the version() method indicating a float return value.
      */
-    protected const VERSION_TYPE_FLOAT = 'float';
+    public const VERSION_TYPE_FLOAT = 'float';
 
     /**
      * List of desktop devices.


### PR DESCRIPTION
The constants are part of the public API contract, i.e. `->version($osName, Agent::VERSION_TYPE_FLOAT)` so they should not be protected visibility.